### PR TITLE
Add Upstash Redis config docs and helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,21 @@ npm run dev:worker
 
 Open http://localhost:3000.
 
+## Redis (Upstash)
+
+Use Upstash Redis for BullMQ in serverless environments.
+
+1. Create a Redis database in Upstash.
+2. Copy the TLS connection string (starts with `rediss://`).
+3. Set environment variables in both `apps/web/.env.local` and `apps/worker/.env.local`:
+
+```bash
+REDIS_URL=rediss://:password@host:port
+BULLMQ_PREFIX=reddit-radar
+```
+
+Serverless note: API routes should only enqueue jobs. Long-lived workers connect from `apps/worker`.
+
 ## Auth flow
 
 - Visit `/login` and request a magic link.

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,2 +1,4 @@
 NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+REDIS_URL=
+BULLMQ_PREFIX=reddit-radar

--- a/apps/worker/.env.example
+++ b/apps/worker/.env.example
@@ -1,0 +1,2 @@
+REDIS_URL=
+BULLMQ_PREFIX=reddit-radar

--- a/packages/jobs/src/index.ts
+++ b/packages/jobs/src/index.ts
@@ -3,3 +3,5 @@ export const queueNames = {
   extract: "extract",
   aggregate: "aggregate"
 };
+
+export { getBullmqPrefix, getRedisConnectionOptions } from "./redis";

--- a/packages/jobs/src/redis.ts
+++ b/packages/jobs/src/redis.ts
@@ -1,0 +1,29 @@
+export type RedisConnectionOptions = {
+  url?: string;
+  host?: string;
+  port?: number;
+  password?: string;
+  tls?: Record<string, unknown> | null;
+};
+
+type Env = Record<string, string | undefined>;
+
+export function getBullmqPrefix(env: Env = process.env) {
+  return env.BULLMQ_PREFIX ?? "reddit-radar";
+}
+
+export function getRedisConnectionOptions(
+  env: Env = process.env
+): RedisConnectionOptions {
+  const url = env.REDIS_URL;
+  if (url) {
+    return { url };
+  }
+
+  const host = env.REDIS_HOST;
+  const port = env.REDIS_PORT ? Number(env.REDIS_PORT) : undefined;
+  const password = env.REDIS_PASSWORD;
+  const tls = env.REDIS_TLS === "true" ? {} : null;
+
+  return { host, port, password, tls };
+}


### PR DESCRIPTION
## Summary
- document Upstash Redis setup and env vars
- add Redis env entries for web/worker
- add BullMQ Redis config helper in `packages/jobs`

## Testing
- not run (docs/config only)

Closes #6
