### PR TITLE
Add extraction schema and prompt v1

### DIFF
--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -30,4 +30,4 @@ export function createSupabaseAdminClient(
   return adminClient;
 }
 
-export { saveThreadWithComments } from "./reddit";
+export { saveThreadWithComments } from "./reddit.js";

--- a/packages/shared/src/extractionSchema.ts
+++ b/packages/shared/src/extractionSchema.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+
+export const extractionSchemaVersion = "v1" as const;
+export const extractionPromptVersion = "v1" as const;
+
+export const extractionSchemaV1 = z.object({
+  summary: z.string(),
+  pain_points: z.array(
+    z.object({
+      problem: z.string(),
+      evidence: z.array(z.string()),
+      severity: z.enum(["low", "medium", "high"]),
+    })
+  ),
+  buying_intent: z.object({
+    level: z.enum(["none", "low", "medium", "high"]),
+    signals: z.array(z.string()),
+    budget: z.string().nullable().optional(),
+    timeline: z.string().nullable().optional(),
+  }),
+  requested_solutions: z.array(z.string()),
+  entities: z.object({
+    companies: z.array(z.string()),
+    products: z.array(z.string()),
+    competitors: z.array(z.string()),
+  }),
+  market_tags: z.array(z.string()),
+});
+
+export type ExtractionV1 = z.infer<typeof extractionSchemaV1>;
+
+export function validateExtractionV1(payload: unknown): ExtractionV1 {
+  const parsed = extractionSchemaV1.safeParse(payload);
+  if (!parsed.success) {
+    throw new Error(`Extraction output invalid: ${parsed.error.message}`);
+  }
+  return parsed.data;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -8,3 +8,11 @@ export {
   type NormalizedComment,
   type NormalizedThreadResult,
 } from "./reddit";
+
+export {
+  extractionSchemaVersion,
+  extractionPromptVersion,
+  extractionSchemaV1,
+  type ExtractionV1,
+  validateExtractionV1,
+} from "./extractionSchema";

--- a/prompts/extract.v1.md
+++ b/prompts/extract.v1.md
@@ -1,0 +1,23 @@
+# Extraction Prompt v1
+
+You are analyzing a Reddit thread (post + comments). Return ONLY valid JSON that matches the schema below.
+
+Rules
+- Output must be a single JSON object (no markdown fences).
+- Do not include trailing commentary or explanations.
+- Prefer empty arrays over nulls. Use null only for optional fields budget/timeline.
+- Use concise, factual language grounded in the provided content.
+
+Schema (summary)
+- summary: string
+- pain_points: array of { problem: string, evidence: string[], severity: low|medium|high }
+- buying_intent: { level: none|low|medium|high, signals: string[], budget?: string|null, timeline?: string|null }
+- requested_solutions: string[]
+- entities: { companies: string[], products: string[], competitors: string[] }
+- market_tags: string[]
+
+Input
+- Thread: {{thread_json}}
+- Comments: {{comments_json}}
+
+Return the JSON object now.

--- a/schemas/extraction.v1.json
+++ b/schemas/extraction.v1.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ExtractionV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "summary",
+    "pain_points",
+    "buying_intent",
+    "requested_solutions",
+    "entities",
+    "market_tags"
+  ],
+  "properties": {
+    "summary": {
+      "type": "string"
+    },
+    "pain_points": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["problem", "evidence", "severity"],
+        "properties": {
+          "problem": { "type": "string" },
+          "evidence": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "severity": {
+            "type": "string",
+            "enum": ["low", "medium", "high"]
+          }
+        }
+      }
+    },
+    "buying_intent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["level", "signals"],
+      "properties": {
+        "level": {
+          "type": "string",
+          "enum": ["none", "low", "medium", "high"]
+        },
+        "signals": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "budget": { "type": ["string", "null"] },
+        "timeline": { "type": ["string", "null"] }
+      }
+    },
+    "requested_solutions": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "entities": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["companies", "products", "competitors"],
+      "properties": {
+        "companies": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "products": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "competitors": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "market_tags": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  }
+}

--- a/supabase/migrations/20251229223000_extraction_versions.sql
+++ b/supabase/migrations/20251229223000_extraction_versions.sql
@@ -1,0 +1,2 @@
+alter table public.extraction
+  add column if not exists schema_version text;


### PR DESCRIPTION
## Summary
- add extraction schema JSON + prompt template v1
- add Zod validator + exports for extraction payloads
- add schema_version column on extraction records
- carry NodeNext export fix in `packages/db/src/index.ts`

## Testing
- not run (schema + migration changes)