### PR TITLE
Remove rootDirectory from vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,4 @@
 {
-  "rootDirectory": "apps/web",
   "buildCommand": "npm run build --workspace @maverick/web",
   "installCommand": "npm install",
   "outputDirectory": "apps/web/.next",


### PR DESCRIPTION
## Summary
- remove unsupported `rootDirectory` from `vercel.json` to satisfy schema validation

## Testing
- not run (config only)