### PR TITLE
Fix worker build by using bundler module resolution

### DIFF
--- a/packages/jobs/tsconfig.json
+++ b/packages/jobs/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true


### PR DESCRIPTION
## Summary
- switch packages/jobs and packages/shared tsconfig to ESNext + Bundler resolution
- avoids TS2835 errors during Render worker build

## Testing
- not run (Render build fix)