### PR TITLE
Use site URL env for magic link redirects

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -6,6 +6,7 @@ RATE_LIMIT_WINDOW_MS=60000
 RATE_LIMIT_MAX=30
 NEXT_PUBLIC_LLM_PROVIDERS=openai,gemini,xai,deepseek
 NEXT_PUBLIC_LLM_MODELS=default
+NEXT_PUBLIC_SITE_URL=https://your-app.vercel.app
 SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 REDDIT_FETCH_TIMEOUT_MS=8000

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -33,11 +33,19 @@ function LoginForm() {
     setStatus("loading");
     setMessage("");
 
+    const baseUrl =
+      process.env.NEXT_PUBLIC_SITE_URL ??
+      process.env.NEXT_PUBLIC_VERCEL_URL ??
+      window.location.origin;
+    const normalizedBaseUrl = baseUrl.startsWith("http")
+      ? baseUrl
+      : `https://${baseUrl}`;
+
     const supabase = createClient();
     const { error } = await supabase.auth.signInWithOtp({
       email,
       options: {
-        emailRedirectTo: `${window.location.origin}/auth/callback?next=${encodeURIComponent(
+        emailRedirectTo: `${normalizedBaseUrl}/auth/callback?next=${encodeURIComponent(
           nextPath
         )}`,
       },


### PR DESCRIPTION
## Summary
- build magic link redirect using NEXT_PUBLIC_SITE_URL or NEXT_PUBLIC_VERCEL_URL
- update `.env.example` with NEXT_PUBLIC_SITE_URL

## Testing
- not run (login redirect change)